### PR TITLE
bypass asJson as not configurable/writable via es6 proxy, fixes #2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 sudo: false
 node_js:
-- '4'
 - '6'
 - '7'
 script:

--- a/index.js
+++ b/index.js
@@ -8,14 +8,13 @@ function traceCaller (pinoInstance) {
     return name === 'asJson' ? asJson : target[name]
   }
 
-  function asJson () {
-    const args = Array.prototype.slice.call(arguments)
+  function asJson (...args) {
     args[0] = args[0] || Object.create(null)
     args[0].caller = Error().stack.split('\n')[STACKTRACE_OFFSET].substr(LINE_OFFSET)
     return pinoInstance.asJson.apply(this, args)
   }
 
-  return new Proxy(pinoInstance, { get: get })
+  return new Proxy(pinoInstance, { get })
 }
 
 module.exports = traceCaller

--- a/index.js
+++ b/index.js
@@ -4,14 +4,18 @@ const STACKTRACE_OFFSET = process && process.version[1] > 6 ? 4 : 5
 const LINE_OFFSET = 7
 
 function traceCaller (pinoInstance) {
-  return Object.assign(Object.create(pinoInstance), {
-    asJson: function () {
-      const args = Array.prototype.slice.call(arguments)
-      args[0] = args[0] || Object.create(null)
-      args[0].caller = Error().stack.split('\n')[STACKTRACE_OFFSET].substr(LINE_OFFSET)
-      return pinoInstance.asJson.apply(this, args)
-    }
-  })
+  function get (target, name) {
+    return name === 'asJson' ? asJson : target[name]
+  }
+
+  function asJson () {
+    const args = Array.prototype.slice.call(arguments)
+    args[0] = args[0] || Object.create(null)
+    args[0].caller = Error().stack.split('\n')[STACKTRACE_OFFSET].substr(LINE_OFFSET)
+    return pinoInstance.asJson.apply(this, args)
+  }
+
+  return new Proxy(pinoInstance, { get: get })
 }
 
 module.exports = traceCaller

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "pino": "*"
   },
   "engines": {
-    "node": ">4.0.0"
+    "node": ">6.0.0"
   },
   "scripts": {
     "lint-fix": "standard --fix index.js examples/*js tests/*.js",


### PR DESCRIPTION
[this change](https://github.com/pinojs/pino/commit/f5da9eab807ccbd719b214b2e6b4ce23eb55d7ec#diff-04e6fb630166e65e0231f8c63a731aa0R113) has broken pino-caller.
i've refactored the plugin to use ES proxy instead of a simple monkey patch in order to bypass the asJson property being declared as not configurable nor writable instead of being attached to the prototype chain.
i didn't try yet, but probably the tests will fail on node v4.

EDIT: yep, it fails on node v4. suggestions?