### PR TITLE
Do not filter pino-caller calls from stack trace

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,9 @@ function traceCaller (pinoInstance) {
 
   function asJson (...args) {
     args[0] = args[0] || Object.create(null)
-    args[0].caller = Error().stack.split('\n').filter(s => !s.includes('node_modules/pino') && !s.includes('node_modules\\pino'))[STACKTRACE_OFFSET].substr(LINE_OFFSET)
+    args[0].caller = Error().stack.split('\n')
+      .filter(s => !s.match(/node_modules[/\\]pino(?!-caller)/))[STACKTRACE_OFFSET]
+      .substr(LINE_OFFSET)
     return pinoInstance[asJsonSym].apply(this, args)
   }
 


### PR DESCRIPTION
The stack trace offset was calculated to include calls to pino-caller
but when installed as a package its path will include
'node_modules/pino'. Use a regular expression that will match all
pino related modules except pino-caller.