### PR TITLE
Add relativeTo to use relative paths instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ pinoCaller.debug('debug1')
 #### Advanced
 ```js
 'use strict'
-// dynamically load the plugin if in development environment
-const pino = process.env.NODE_ENV === 'development' ? require('pino-caller')(require('pino')()) : require('pino')()
+// dynamically load the plugin if in development environment, output paths relative to __dirname
+const pino = process.env.NODE_ENV === 'development' ? require('pino-caller')(require('pino')(), __dirname) : require('pino')()
 
 pino.info('info1')
 pino.error('error1')
@@ -57,6 +57,6 @@ You can find also a working example in the `examples` directory and you can run 
 > env NODE_ENV=development node examples/index.js
 
 {"pid":44837,"hostname":"debian","level":30,"time":1487873713227,"msg":"hello from the module!","caller":"Object.<anonymous> (/home/phra/git/pino-caller/examples/module.js:4:12)","v":1}
-{"pid":44837,"hostname":"debian","level":30,"time":1487873713230,"msg":"info1","caller":"Object.<anonymous> (/home/phra/git/pino-caller/examples/index.js:8:12)","v":1}
-{"pid":44837,"hostname":"debian","level":50,"time":1487873713230,"msg":"error1","caller":"Object.<anonymous> (/home/phra/git/pino-caller/examples/index.js:9:12)","v":1}
+{"pid":44837,"hostname":"debian","level":30,"time":1487873713230,"msg":"info1","caller":"Object.<anonymous> (index.js:8:12)","v":1}
+{"pid":44837,"hostname":"debian","level":50,"time":1487873713230,"msg":"error1","caller":"Object.<anonymous> (index.js:9:12)","v":1}
 ```

--- a/examples/index.js
+++ b/examples/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const pino = process.env.NODE_ENV === 'development' ? require('../')(require('pino')()) : require('pino')()
+const pino = process.env.NODE_ENV === 'development' ? require('../')(require('pino')(), __dirname) : require('pino')()
 
 require('./module')
 

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const LINE_OFFSET = 7
 const { symbols } = require('pino')
 const { asJsonSym } = symbols
 
-function traceCaller (pinoInstance) {
+function traceCaller (pinoInstance, relativeTo) {
   function get (target, name) {
     return name === asJsonSym ? asJson : target[name]
   }
@@ -15,6 +15,9 @@ function traceCaller (pinoInstance) {
   function asJson (...args) {
     args[0] = args[0] || Object.create(null)
     args[0].caller = Error().stack.split('\n').slice(2).filter(s => !s.includes('node_modules/pino') && !s.includes('node_modules\\pino'))[STACKTRACE_OFFSET].substr(LINE_OFFSET)
+    if (typeof relativeTo === 'string') {
+      args[0].caller = args[0].caller.replace(relativeTo, '');
+    }
     return pinoInstance[asJsonSym].apply(this, args)
   }
 

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ function traceCaller (pinoInstance, relativeTo) {
     args[0] = args[0] || Object.create(null)
     args[0].caller = Error().stack.split('\n').slice(2).filter(s => !s.includes('node_modules/pino') && !s.includes('node_modules\\pino'))[STACKTRACE_OFFSET].substr(LINE_OFFSET)
     if (typeof relativeTo === 'string') {
-      args[0].caller = args[0].caller.replace(relativeTo, '');
+      args[0].caller = args[0].caller.replace(relativeTo + '/', '').replace(relativeTo + '\\', '')
     }
     return pinoInstance[asJsonSym].apply(this, args)
   }

--- a/tests/test.js
+++ b/tests/test.js
@@ -78,3 +78,17 @@ test('pino caller works also with pino plugins', function (t) {
 
   pinoInstance.info('test')
 })
+
+test('pino caller works also with relativeTo parameter set', function (t) {
+  t.plan(3)
+
+  const pinoInstance = pinoCaller(pino(through2(function (chunk, enc, callback) {
+    const res = JSON.parse(chunk.toString('utf8'))
+    const regex = /Test.<anonymous> \(test.js/
+    t.ok(res.caller, 'caller property is set')
+    t.equal(typeof res.caller, 'string', 'caller property is a string')
+    t.ok(regex.test(res.caller), 'caller property matches the test regex')
+  })), __dirname)
+
+  pinoInstance.info('test')
+})


### PR DESCRIPTION
Fixes #29 

Currently the library outputs absolute paths that include uninteresting "path from system root to project root" part that is the same for every single record. It creates clutter and makes logs harder to read. To resolve that I propose relativeTo string param that will cut the part of path that matches relativeTo.