### PR TITLE
Add option.stackAdjustment

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,24 @@ pino.debug('debug1')
 
 You can find also a working example in the `examples` directory and you can run it with `npm run example`
 
+##### Options
+
+- **relativeTo** - Remove path prefixes from log messages to make them easier to read.
+- **stackAdjustment** - For those of who who've wrapped pino, make pino-caller move N stackframes up to get a meaningful message.
+
+```js
+'use strict'
+const pino = require('pino')()
+const pinoCaller = require('pino-caller')(pino, { relativeTo: __dirname, stackAdjustment: 1 })
+
+// People who have wrapped pino like in the contrived example below 
+// will want to use stackAdjustment.
+// Most people will NOT need this.  See issue #90 for details.
+const log = {
+  info: function(message) { pinoCaller.info(message) }
+}
+```
+
 ### Example output
 
 ```

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,6 +7,7 @@ import { Logger } from 'pino';
 
 interface Options {
     relativeTo?: string;
+    stackAdjustment?: number;
 }
 
 declare function pinoCaller(logger: Logger, options?: Options): Logger;

--- a/index.js
+++ b/index.js
@@ -7,14 +7,16 @@ const LINE_OFFSET = 7
 const { symbols } = require('pino')
 const { asJsonSym } = symbols
 
-function traceCaller (pinoInstance, options = {relativeTo: null}) {
+function traceCaller (pinoInstance, options = {relativeTo: null, stackAdjustment: 0}) {
+  const adjustment = options.stackAdjustment || 0
+
   function get (target, name) {
     return name === asJsonSym ? asJson : target[name]
   }
 
   function asJson (...args) {
     args[0] = args[0] || Object.create(null)
-    args[0].caller = Error().stack.split('\n').slice(2).filter(s => !s.includes('node_modules/pino') && !s.includes('node_modules\\pino'))[STACKTRACE_OFFSET].substr(LINE_OFFSET)
+    args[0].caller = Error().stack.split('\n').slice(2).filter(s => !s.includes('node_modules/pino') && !s.includes('node_modules\\pino'))[STACKTRACE_OFFSET + adjustment].substr(LINE_OFFSET)
     if (options && typeof options.relativeTo === 'string') {
       const lastChar = options.relativeTo[options.relativeTo.length - 1]
       const hasTrailingSlash = lastChar === '/' || lastChar === '\\'

--- a/tests/test.js
+++ b/tests/test.js
@@ -107,3 +107,23 @@ test('pino caller works also when relativeTo has a trailing slash', function (t)
 
   pinoInstance.info('test')
 })
+
+test('pino caller can make stack adjustments', function(t) {
+  t.plan(3)
+
+  const pinoInstance = pinoCaller(pino(through2(function (chunk, enc, callback) {
+    const res = JSON.parse(chunk.toString('utf8'))
+    const regex = /Test.<anonymous> \(\/(.)*tests\/test.js/
+    t.ok(res.caller, 'caller property is set')
+    t.equal(typeof res.caller, 'string', 'caller property is a string')
+    t.ok(regex.test(res.caller), 'caller property matches the test regex')
+  })), { stackAdjustment: 1 })
+
+  // Create a wrapper around pino so that we can show that stackAdjustment can bypass this stack frame.
+  const log = {
+    info: function(message) {
+      pinoInstance.info(message)
+    }
+  }
+  log.info('test')
+})


### PR DESCRIPTION
I added a new option `stackAdjustment` to pino-caller to help people fine tune which stack frame they want to use for logging purposes.  It's needed by people who have wrapped pino, because the default behavior gets the wrong frame, but if a small constant adjustment could be applied, the right frame could be found.

This should address the concerns in issue #90.