### PR TITLE
docs(readme): fix broken badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## pino-caller
 [![npm version](https://img.shields.io/npm/v/pino-caller)](https://www.npmjs.com/package/pino-caller)
-[![Build Status](https://img.shields.io/github/workflow/status/pinojs/pino-caller/CI)](https://github.com/pinojs/pino-caller/actions)
+[![Build Status](https://img.shields.io/github/actions/workflow/status/pinojs/pino-caller/ci.yml?branch=master)](https://github.com/pinojs/pino-caller/actions)
 [![Coverage Status](https://coveralls.io/repos/github/pinojs/pino-caller/badge.svg?branch=master)](https://coveralls.io/github/pinojs/pino-caller?branch=master)
 [![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)](https://standardjs.com/)
 


### PR DESCRIPTION
### Before

[![Build Status](https://img.shields.io/github/workflow/status/pinojs/pino-caller/CI)](https://github.com/pinojs/pino-caller/actions)

### After

[![Build Status](https://img.shields.io/github/actions/workflow/status/pinojs/pino-caller/ci.yml?branch=master)](https://github.com/pinojs/pino-caller/actions)